### PR TITLE
bugfix/accurics_remediation_5642543405024141 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,8 @@ variable "web_min_size" {
 }
 
 provider "aws" {
-  profile = "default"
-  region  = "us-west-2"
+  profile                 = "default"
+  region                  = "us-west-2"
   shared_credentials_file = "$HOME/.aws/credentials"
 }
 
@@ -28,6 +28,11 @@ resource "aws_s3_bucket" "prod_tf_course" {
   acl    = "private"
   tags = {
     "Terraform" : "true"
+  }
+
+  versioning {
+    enabled    = true
+    mfa_delete = true
   }
 }
 


### PR DESCRIPTION
Perform the steps below to enable MFA delete on an S3 bucket.

Note:
-You cannot enable MFA Delete using the AWS Management Console. You must use the AWS CLI or API.
-You must use your 'root' account to enable MFA Delete on S3 buckets.

**From Command line:**

1. Run the s3api put-bucket-versioning command

```
aws s3api put-bucket-versioning --profile my-root-profile --bucket Bucket_Name --versioning-configuration Status=Enabled,MFADelete=Enabled --mfa “arn:aws:iam::aws_account_id:mfa/root-account-mfa-device passcode”
```.