### PR TITLE
bugfix/accurics_remediation_7697701493472486 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,15 @@ resource "aws_s3_bucket" "prod_tf_course" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = "<master_kms_key_id>"
+      }
+    }
+  }
 }
 
 resource "aws_default_vpc" "default" {}


### PR DESCRIPTION
Server-side encryption protects data at rest. Amazon S3 encrypts each object with a unique key. As an additional safeguard, it encrypts the key itself with a key that it rotates regularly. Amazon S3 server-side encryption uses one of the strongest block ciphers available to encrypt your data using AWS KMS Customer managed key.
 In Terraform - 
 Add the 'server_side_encryption_configuration' block to ensure server side encryption is enabled. Ensure 'see_algorithm' is set to 'aws:kms' and add a 'kms_master_key_id'.