### PR TITLE
bugfix/accurics_remediation_43722118955007483 - Auto Generated Pull Request From Accurics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,14 @@ resource "aws_s3_bucket" "prod_tf_course" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_default_vpc" "default" {}


### PR DESCRIPTION
Server-side encryption protects data at rest. Amazon S3 encrypts each object with a unique key. As an additional safeguard, it encrypts the key itself with a key that it rotates regularly. Amazon S3 server-side encryption uses one of the strongest block ciphers available to encrypt your data, 256-bit Advanced Encryption Standard (AES-256).
 In Terraform - 
 Add the 'server_side_encryption_configuration' block to ensure server side encryption is enabled. Set 'sse_alogrithm' set to 'AES256'.